### PR TITLE
Update dask and conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,41 +1,98 @@
 name: ngcm
+channels: !!python/object/new:ruamel_yaml.comments.CommentedSeq
+  listitems:
+  - conda-forge
+  - defaults
+  state: !!python/tuple
+  - _yaml_format: !!python/object:ruamel_yaml.comments.Format
+      _flow_style: false
+    _yaml_line_col: !!python/object:ruamel_yaml.comments.LineCol
+      col: 2
+      data:
+        0:
+        - 5
+        - 4
+        1:
+        - 6
+        - 4
+      line: 5
+  - _yaml_comment: !!python/object:ruamel_yaml.comments.Comment
+      _end: []
+      _items:
+        1:
+        - !!python/object:ruamel_yaml.tokens.CommentToken
+          end_mark: !!python/object:ruamel_yaml.error.Mark
+            buffer: null
+            column: 12
+            index: 91
+            line: 6
+            name: /Users/civisemployee/.condarc
+            pointer: null
+          start_mark: !!python/object:ruamel_yaml.error.Mark
+            buffer: null
+            column: 4
+            index: 83
+            line: 6
+            name: /Users/civisemployee/.condarc
+            pointer: null
+          value: '
+
+
+            '
+        - null
+        - null
+        - null
+      comment: null
 dependencies:
 - appnope=0.1.0
 - backports=1.0
 - bokeh=0.11.1
-- ca-certificates=2016.2.28
-- cloudpickle=0.2.1
-- cycler=0.10.0
-- dask=0.9.0
+- boto3=1.3.1
+- botocore=1.4.26
+- click=6.6
+- conda-forge::ca-certificates=2016.2.28
+- conda-forge::cloudpickle=0.2.1
+- conda-forge::cycler=0.10.0
+- conda-forge::dask=0.10.0
+- conda-forge::distributed=1.11.0
+- conda-forge::entrypoints=0.2.1
+- conda-forge::freetype=2.6.3
+- conda-forge::ipykernel=4.3.1
+- conda-forge::ipywidgets=5.1.5
+- conda-forge::jsonschema=2.5.1
+- conda-forge::matplotlib=1.5.1
+- conda-forge::openssl=1.0.2h
+- conda-forge::pandas=0.18.1
+- conda-forge::pexpect=4.1.0
+- conda-forge::pickleshare=0.7.2
+- conda-forge::psutil=4.1.0
+- conda-forge::ptyprocess=0.5.1
+- conda-forge::s3fs=0.0.6
+- conda-forge::terminado=0.6
+- conda-forge::tk=8.5.19
+- conda-forge::widgetsnbextension=1.2.3
+- conda-forge::zlib=1.2.8
 - decorator=4.0.9
-- entrypoints=0.2.1
-- freetype=2.6.3
+- docutils=0.12
 - get_terminal_size=1.0.0
-- ipykernel=4.3.1
 - ipython=4.2.0
 - ipython_genutils=0.1.0
-- ipywidgets=5.1.5
 - jinja2=2.8
-- jsonschema=2.5.1
+- jmespath=0.9.0
 - jupyter_client=4.2.2
 - jupyter_core=4.1.0
-- libpng=1.6.21
+- libpng=1.6.17
 - locket=0.2.0
 - markupsafe=0.23
-- matplotlib=1.5.1
 - mistune=0.7.2
 - mkl=11.3.3
+- msgpack-python=0.4.6
 - nbconvert=4.2.0
 - nbformat=4.0.1
 - notebook=4.2.0
 - numpy=1.11.0
-- openssl=1.0.2h
-- pandas=0.18.1
 - partd=0.3.3
-- pexpect=4.1.0
-- pickleshare=0.7.2
 - pip=8.1.1
-- ptyprocess=0.5.1
 - pygments=2.1.3
 - pyparsing=2.1.4
 - python=3.5.1
@@ -52,19 +109,18 @@ dependencies:
 - simplegeneric=0.8.1
 - six=1.10.0
 - sqlite=3.9.2
-- terminado=0.6
-- tk=8.5.19
+- tblib=1.3.0
 - toolz=0.7.4
 - tornado=4.3
 - traitlets=4.2.1
 - wheel=0.29.0
-- widgetsnbextension=1.2.3
 - xz=5.0.5
 - yaml=0.1.6
-- zlib=1.2.8
 - pip:
   - backports.shutil-get-terminal-size==1.0.0
+  - cycler==0.10.0
   - ipython-genutils==0.1.0
   - jupyter-client==4.2.2
   - jupyter-core==4.1.0
+prefix: /Users/civisemployee/.miniconda3/envs/ngcm
 


### PR DESCRIPTION
Updated conda to 4.1.x. Updated to newest released dask. Updated my condarc to prefer `conda-forge`, which is now included in the environment, apparently. I'm not sure why there are hard-coded paths on my machine either. Probably deserves some vetting.
